### PR TITLE
Evaluation of expression containing variables

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,22 @@ mod converter;
 mod evaluator;
 mod tokenizer;
 
-/// Expression evaluation
+use std::collections::HashMap;
+
+/// Evaluation of expression without variables
 pub fn evaluate(expression: &String) -> Result<f64, String> {
-    let tokens: Vec<token::Token> = tokenizer::tokenize(expression.as_str())?;
+    let variables: HashMap<String, f64> = HashMap::new();
+    let tokens: Vec<token::Token> = tokenizer::tokenize(expression.as_str(), &variables)?;
+
+    let posfix_tokens: Vec<token::Token> = converter::infix_to_postfix(&tokens)?;
+    return evaluator::postfix_evaluation(&posfix_tokens);
+}
+
+pub fn evaluate_with_variables(
+    expression: &String,
+    variables: &HashMap<String, f64>,
+) -> Result<f64, String> {
+    let tokens: Vec<token::Token> = tokenizer::tokenize(expression.as_str(), variables)?;
     let posfix_tokens: Vec<token::Token> = converter::infix_to_postfix(&tokens)?;
     return evaluator::postfix_evaluation(&posfix_tokens);
 }
@@ -107,6 +120,44 @@ mod tests {
             (2.0 - std::f64::consts::PI).sin() * ((-std::f64::consts::PI + 2.0) / 2.0).cos();
 
         match evaluate(&expression) {
+            Ok(result) => assert!(relative_error(result, reference) < 0.01),
+            Err(_) => assert!(false),
+        }
+    }
+
+    #[test]
+    fn test_evaluation_expression_with_variables() {
+        let expression: String = String::from("left - right");
+
+        let left: f64 = 43.75;
+        let right: f64 = 20.97;
+        let reference: f64 = left - right;
+
+        let variables: HashMap<String, f64> =
+            HashMap::from([(String::from("left"), left), (String::from("right"), right)]);
+
+        match evaluate_with_variables(&expression, &variables) {
+            Ok(result) => assert!(relative_error(result, reference) < 0.01),
+            Err(_) => assert!(false),
+        }
+    }
+
+    #[test]
+    fn test_evaluation_expression_with_variables_and_function() {
+        let expression: String = String::from("left - right + sqrt(arg)");
+
+        let left: f64 = 43.75;
+        let right: f64 = 20.97;
+        let arg: f64 = 9.0;
+        let reference: f64 = left - right + arg.sqrt();
+
+        let variables: HashMap<String, f64> = HashMap::from([
+            (String::from("left"), left),
+            (String::from("right"), right),
+            (String::from("arg"), arg),
+        ]);
+
+        match evaluate_with_variables(&expression, &variables) {
             Ok(result) => assert!(relative_error(result, reference) < 0.01),
             Err(_) => assert!(false),
         }


### PR DESCRIPTION
From now we can evaluate an expression containing variables. These variables are defined in form of HashMap<String, f64> where we associate their name with their values. 